### PR TITLE
Add thread number param to labyrinth and vaction

### DIFF
--- a/labyrinth/README
+++ b/labyrinth/README
@@ -33,6 +33,7 @@ By default, this produces an executable named "labyrinth", which can then be
 run in the following manner:
 
     ./labyrinth -i <input_file>
+                -t <number_of_thread>
 
 The following input file is recommended for simulated runs:
 

--- a/labyrinth/labyrinth.c
+++ b/labyrinth/labyrinth.c
@@ -154,6 +154,8 @@ parseArgs (long argc, char* const argv[])
         switch (opt) {
             case 'b':
             case 't':
+                global_params[PARAM_THREAD] = atol(optarg);
+                break;
             case 'x':
             case 'y':
             case 'z':

--- a/vacation/README
+++ b/vacation/README
@@ -32,7 +32,8 @@ run in the following manner:
                -q <%_of_relations_queried> \
                -r <number_possible_relations> \
                -u <%_of_user_tasks> \
-               -t <number_of_tasks>
+               -t <number_of_tasks> \
+               -c <number_of_thread/client>
 
 The following values are recommended for simulated runs:
 

--- a/vacation/vacation.c
+++ b/vacation/vacation.c
@@ -165,10 +165,13 @@ parseArgs (long argc, char* const argv[])
     while ((opt = getopt(argc, argv, "c:n:q:r:t:u:")) != -1) {
         switch (opt) {
             case 'c':
+                global_params[PARAM_CLIENTS] = atol(optarg);
+                break;
             case 'n':
             case 'q':
             case 'r':
             case 't':
+
             case 'u':
                 global_params[(unsigned char)opt] = atol(optarg);
                 break;


### PR DESCRIPTION
Labyrinth and vaction missed the parameters of thread number in
execute command. Parameters and documents are added to support
multi-threading in both of them.